### PR TITLE
Update _get_column_info()

### DIFF
--- a/ISLP/models/columns.py
+++ b/ISLP/models/columns.py
@@ -148,7 +148,7 @@ def _get_column_info(X,
             name = f'X{col}'
         else:
             name = str(col)
-        if is_categorical[i]:
+        if is_categorical.iloc[i]:
             if is_ordinal[i]:
                 Xcol = _get_column(col, X) 
                 encoder = clone(default_encoders['ordinal'])


### PR DESCRIPTION
Series.__getitem__ treating keys as positions is deprecated.

See: https://github.com/pandas-dev/pandas/pull/53201

See: https://github.com/pandas-dev/pandas/blob/2.1.x/pandas/core/series.py#L1027-L1037

```python
if is_integer(key) and self.index._should_fallback_to_positional:
    warnings.warn(
        # GH#50617
        "Series.__getitem__ treating keys as positions is deprecated. "
        "In a future version, integer keys will always be treated "
        "as labels (consistent with DataFrame behavior). To access "
        "a value by position, use `ser.iloc[pos]`",
        FutureWarning,
        stacklevel=find_stack_level(),
    )
    return self._values[key]
```