### PR TITLE
Fix warning: Passing html literal strings is deprecated.

### DIFF
--- a/ISLP/models/__init__.py
+++ b/ISLP/models/__init__.py
@@ -4,6 +4,7 @@ and select regression models.
 
 """
 import numpy as np, pandas as pd
+from io import StringIO
 
 from .model_spec import (ModelSpec,
                          Column,
@@ -46,7 +47,7 @@ def summarize(results,
 
     """
     tab = results.summary().tables[1]
-    results_table = pd.read_html(tab.as_html(),
+    results_table = pd.read_html(StringIO(tab.as_html()),
                                  index_col=0,
                                  header=0)[0]
     if not conf_int:


### PR DESCRIPTION
See: https://github.com/pandas-dev/pandas/pull/53805

Passing html literal strings is deprecated.

Wrap literal string/bytes input in ``io.StringIO``/``io.BytesIO`` instead.