### PR TITLE
fix backward feature selection for fixed_steps

### DIFF
--- a/ISLP/models/strategy.py
+++ b/ISLP/models/strategy.py
@@ -403,7 +403,7 @@ class Stepwise(MinMaxCandidates):
                 initial_terms_.append(term)
             initial_state = tuple(initial_terms_)
         else:
-            initial_state = ()
+            initial_state = () if direction == 'forward' else list(model_spec.terms)
 
         if not parsimonious:
             _postprocess = _postprocess_best
@@ -455,27 +455,28 @@ class Stepwise(MinMaxCandidates):
 
         """
 
+        n_terms = n_steps if direction == 'forward' else len(list(model_spec.terms)) - n_steps
         step = Stepwise(model_spec,
                         direction=direction,
-                        min_terms=n_steps,
-                        max_terms=n_steps,
+                        min_terms=n_terms,
+                        max_terms=n_terms,
                         lower_terms=lower_terms,
                         upper_terms=upper_terms,
                         validator=validator)
 
         # pick an initial state
 
-        if initial_terms is not None:
+        if initial_terms is not None and initial_terms != []:
             initial_terms_ = []
+            mm_terms = list(model_spec.terms)
             for term in initial_terms:
-                mm_terms = list(model_spec.terms)
                 if term in mm_terms:
                     idx = mm_terms.index(term)
                     term = model_spec.terms_[idx]
                 initial_terms_.append(term)
             initial_state = tuple(initial_terms_)
         else:
-            initial_state = ()
+            initial_state = () if direction == 'forward' else list(model_spec.terms_)
 
         if not step.lower_terms.issubset(initial_state):
             raise ValueError('initial_state should contain %s' % str(step.lower_terms))
@@ -486,8 +487,8 @@ class Stepwise(MinMaxCandidates):
         return Strategy(initial_state,
                         step.candidate_states,
                         model_spec.build_submodel,
-                        partial(fixed_steps, n_steps),
-                        partial(_postprocess_fixed_steps, n_steps))
+                        partial(fixed_steps, n_terms),
+                        partial(_postprocess_fixed_steps, n_terms))
     
 
 def min_max(model_spec,

--- a/tests/models/test_selection.py
+++ b/tests/models/test_selection.py
@@ -113,7 +113,45 @@ def test_step():
         print(step_selector.results_)
         print(step_selector.selected_state_)
         print('huh')
-        
+
+def test_fixed_steps_backward():
+
+    n, p = 100, 7
+    rng = np.random.default_rng(1)
+    X = rng.standard_normal((n, p))
+    Y = rng.standard_normal(n)
+    D = pd.DataFrame(X, columns=['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J'][:p])
+    D['A'] = pd.Categorical(rng.choice(range(5), (n,), replace=True))
+
+    model_spec = MS(list(D.columns))
+    model_spec.fit(D)
+
+    num_steps = 4
+    strategy = Stepwise.fixed_steps(model_spec,
+                                        num_steps,
+                                        direction='backward')
+
+    step_selector = FeatureSelector(LinearRegression(),
+                                    strategy,
+                                    cv=3)
+    step_selector.fit(D, Y)
+
+    print("selected", [term.name for term in step_selector.selected_state_])
+    assert len(step_selector.selected_state_) == (len(model_spec.terms) - num_steps)
+
+    num_steps = 2
+    strategy = Stepwise.fixed_steps(model_spec,
+                                    num_steps,
+                                    direction='backward')
+
+    step_selector = FeatureSelector(LinearRegression(),
+                                    strategy,
+                                    cv=None)
+    step_selector.fit(D, Y)
+
+    print("selected", [term.name for term in step_selector.selected_state_])
+    assert len(step_selector.selected_state_) == (len(model_spec.terms) - num_steps)
+
 def test_constraint():
 
     rng = np.random.default_rng(3)


### PR DESCRIPTION
Backward feature selection has some issues, namely:

- n_terms is incorrect as it should be the num_available_features - n_steps
- initial_state is incorrect as it should be the list of initial predictors in backward selection

@jonathan-taylor do you mind taking a review here? only tried to fix the `fixed_steps` case, but I imagine `first_peak` has the same issue as well.

Love the ISLP library and book by the way! I just found this issue while going through the exercises in chapter 6, 8.d was not possible to do with the current package. LMK if the fix looks good :)